### PR TITLE
Exclude click v8.2.2 from dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v0.6.3 (in development)
+-----------------------
+- Exclude click v8.2.2 from dependencies due to breakage caused by
+  https://github.com/pallets/click/issues/3024
+
 v0.6.2 (2025-05-11)
 -------------------
 - Update tests for click v8.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 
 dependencies = [
     "attrs            >= 18.1",
-    "click            ~= 8.2",
+    "click            ~= 8.2, != 8.2.2",
     "packaging",
     "backports.cached-property; python_version < '3.8'",
     "pydantic         ~= 2.0",

--- a/src/check_wheel_contents/__init__.py
+++ b/src/check_wheel_contents/__init__.py
@@ -12,7 +12,7 @@ README, along with common causes and corresponding fixes.
 Visit <https://github.com/jwodder/check-wheel-contents> for more information.
 """
 
-__version__ = "0.6.2"
+__version__ = "0.6.3.dev1"
 __author__ = "John Thorvald Wodder II"
 __author_email__ = "check-wheel-contents@varonathe.org"
 __license__ = "MIT"


### PR DESCRIPTION
Closes #48.